### PR TITLE
Disable auto re-subscribe when socket is reconnected

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,7 @@ export default class ClusterWS {
 
   public subscribe(channelName: string): Channel {
     return this.channels[channelName] ? this.channels[channelName] :
-      this.channels[channelName] = new Channel(this, channelName, this.options.autoResubscribe);
+      this.channels[channelName] = new Channel(this, channelName);
   }
 
   public getChannelByName(channelName: string): Channel {

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,6 +110,9 @@ export default class ClusterWS {
       }
     };
     this.websocket.onclose = (event: CloseEvent): void => {
+      if (!this.options.autoResubscribe) {
+        this.channels = {}
+      }
       clearTimeout(this.pingTimeout)
       this.events.emit('disconnect', event.code, event.reason)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,8 @@ export default class ClusterWS {
       } : { attempts: 0, minInterval: 1000, maxInterval: 5000 },
       encodeDecodeEngine: configurations.encodeDecodeEngine || false,
       autoConnect: configurations.autoConnect !== false,
-    }
+      autoResubscribe: configurations.autoResubscribe !== false,
+    };
 
     if (!this.options.url)
       return logError('Url must be provided and it must be a string')
@@ -81,7 +82,7 @@ export default class ClusterWS {
 
   public subscribe(channelName: string): Channel {
     return this.channels[channelName] ? this.channels[channelName] :
-      this.channels[channelName] = new Channel(this, channelName)
+      this.channels[channelName] = new Channel(this, channelName, this.options.autoResubscribe);
   }
 
   public getChannelByName(channelName: string): Channel {
@@ -102,9 +103,12 @@ export default class ClusterWS {
 
     this.websocket.onopen = (): void => {
       this.reconnectionAttempted = 0
-      for (let i: number = 0, keys: string[] = Object.keys(this.channels), keysLength: number = keys.length; i < keysLength; i++)
-        this.channels.hasOwnProperty(keys[i]) && this.channels[keys[i]].subscribe()
-    }
+      if (this.options.autoResubscribe) {
+        for (let i: number = 0, keys: string[] = Object.keys(this.channels), keysLength: number = keys.length; i < keysLength; i++) {
+          this.channels.hasOwnProperty(keys[i]) && this.channels[keys[i]].subscribe();
+        }
+      }
+    };
     this.websocket.onclose = (event: CloseEvent): void => {
       clearTimeout(this.pingTimeout)
       this.events.emit('disconnect', event.code, event.reason)

--- a/src/modules/channel.ts
+++ b/src/modules/channel.ts
@@ -7,10 +7,10 @@ export class Channel {
   private socket: ClusterWS
   private listener: Listener
 
-  constructor(socket: ClusterWS, name: string) {
+    constructor(socket: ClusterWS, name: string, autoResubscribe: boolean) {
     this.name = name
     this.socket = socket
-    this.subscribe()
+    autoResubscribe && this.subscribe();
   }
 
   public watch(listener: Listener): Channel {

--- a/src/modules/channel.ts
+++ b/src/modules/channel.ts
@@ -7,10 +7,10 @@ export class Channel {
   private socket: ClusterWS
   private listener: Listener
 
-    constructor(socket: ClusterWS, name: string, autoResubscribe: boolean) {
+  constructor(socket: ClusterWS, name: string) {
     this.name = name
     this.socket = socket
-    autoResubscribe && this.subscribe();
+    this.subscribe()
   }
 
   public watch(listener: Listener): Channel {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -14,6 +14,7 @@ export type Options = {
     minInterval: number
     maxInterval: number
   }
+  autoResubscribe: boolean;
   encodeDecodeEngine: EncodeDecodeEngine | false
 }
 
@@ -26,6 +27,7 @@ export type Configurations = {
     minInterval?: number
     maxInterval?: number
   }
+  autoResubscribe?: boolean;
   encodeDecodeEngine?: EncodeDecodeEngine
 }
 


### PR DESCRIPTION
### Submitting
<!-- Select from following by placing `x` between braces like: [x] -->
- [ ] Bug fix
- [x] Feature
- [ ] Other

### Details
<!-- Describe what you are submitting as clear as possible -->
I need this feature to hold resubscribe before the socket is authenticated. Will this fix #51?